### PR TITLE
Changed the .hidden class to .timeline-hidden

### DIFF
--- a/dist/angular-timeline-animations.css
+++ b/dist/angular-timeline-animations.css
@@ -1,4 +1,4 @@
-.hidden {
+.timeline-hidden {
   display: block !important;
   opacity: 0; }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,11 +18,17 @@
     // before the base attribute is added, causing 404 and terribly slow loading of the docs app.
     (function() {
       var indexFile = (location.pathname.match(/\/(index[^\.]*\.html)/) || ['', ''])[1],
-          rUrl = /(#!\/|api|index[^\.]*\.html).*$/,
-          origin = location.origin || (window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '')),
-          baseUrl = origin + location.href.substr(origin.length).replace(rUrl, indexFile),
+          origin, baseUrl, rUrl = /(\/?#!\/.*|\/(api)\/?(\?.*)*|\/index[^\.]*\.html.*)$/,
           headEl = document.getElementsByTagName('head')[0],
           sync = true;
+
+      if (location.href.slice(0, 7) == 'file://') {
+        baseUrl = location.href.replace(rUrl, '/' + indexFile);
+      } else {
+        origin = location.origin || (window.location.protocol + "//" + window.location.hostname +
+                                    (window.location.port ? ':' + window.location.port: ''));
+        baseUrl = origin + location.href.substr(origin.length).replace(rUrl, '/' + indexFile);
+      }
 
       addTag('base', {href: baseUrl});
       addTag('link', {rel: 'stylesheet', href: 'css/bootstrap.min.css', type: 'text/css'});
@@ -165,9 +171,9 @@
             <li class="nav-header section" ng-show="module.services.length">
               <a class="guide">service</a>
             </li>
-            <li ng-repeat="service in module.services track by service.instance.url" ng-class="navClass(service.instance, service.provider)" class="api-list-item expand">
+            <li ng-repeat="service in module.services track by  (service.instance.url || service.provider.url)" ng-class="navClass(service.instance, service.provider)" class="api-list-item expand">
               <a ng-show="service.provider" class="pull-right" href="{{service.provider.url}}" tabindex="2"><i class="icon-cog"></i></a>
-              <a href="{{service.instance.url}}" tabindex="2">{{service.name}}</a>
+              <a href="{{service.instance ? service.instance.url : service.provider.url}}" tabindex="2">{{service.name}}</a>
             </li>
 
             <li class="nav-header section" ng-show="module.types.length">

--- a/docs/partials/api/angular-timeline.directive.timeline-badge.html
+++ b/docs/partials/api/angular-timeline.directive.timeline-badge.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/npm/npm.git/edit/master/dist/angular-timeline.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/npm/npm.git/blob/e76d86b/dist/angular-timeline.js#L11" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">timeline-badge</code>
+<a href="https://github.com/npm/npm/edit/master/dist/angular-timeline.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/npm/npm/blob/1608584/dist/angular-timeline.js#L11" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">timeline-badge</code>
 <div><span class="hint">directive in module <code ng:non-bindable="">angular-timeline</code>
 </span>
 </div>

--- a/docs/partials/api/angular-timeline.directive.timeline-footer.html
+++ b/docs/partials/api/angular-timeline.directive.timeline-footer.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/npm/npm.git/edit/master/dist/angular-timeline.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/npm/npm.git/blob/e76d86b/dist/angular-timeline.js#L67" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">timeline-footer</code>
+<a href="https://github.com/npm/npm/edit/master/dist/angular-timeline.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/npm/npm/blob/1608584/dist/angular-timeline.js#L67" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">timeline-footer</code>
 <div><span class="hint">directive in module <code ng:non-bindable="">angular-timeline</code>
 </span>
 </div>

--- a/docs/partials/api/angular-timeline.directive.timeline-heading.html
+++ b/docs/partials/api/angular-timeline.directive.timeline-heading.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/npm/npm.git/edit/master/dist/angular-timeline.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/npm/npm.git/blob/e76d86b/dist/angular-timeline.js#L85" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">timeline-heading</code>
+<a href="https://github.com/npm/npm/edit/master/dist/angular-timeline.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/npm/npm/blob/1608584/dist/angular-timeline.js#L85" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">timeline-heading</code>
 <div><span class="hint">directive in module <code ng:non-bindable="">angular-timeline</code>
 </span>
 </div>

--- a/docs/partials/api/angular-timeline.directive.timeline-panel.html
+++ b/docs/partials/api/angular-timeline.directive.timeline-panel.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/npm/npm.git/edit/master/dist/angular-timeline.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/npm/npm.git/blob/e76d86b/dist/angular-timeline.js#L103" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">timeline-panel</code>
+<a href="https://github.com/npm/npm/edit/master/dist/angular-timeline.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/npm/npm/blob/1608584/dist/angular-timeline.js#L103" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">timeline-panel</code>
 <div><span class="hint">directive in module <code ng:non-bindable="">angular-timeline</code>
 </span>
 </div>

--- a/docs/partials/api/angular-timeline.directive.timeline.html
+++ b/docs/partials/api/angular-timeline.directive.timeline.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/npm/npm.git/edit/master/dist/angular-timeline.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/npm/npm.git/blob/e76d86b/dist/angular-timeline.js#L49" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">timeline</code>
+<a href="https://github.com/npm/npm/edit/master/dist/angular-timeline.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/npm/npm/blob/1608584/dist/angular-timeline.js#L49" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">timeline</code>
 <div><span class="hint">directive in module <code ng:non-bindable="">angular-timeline</code>
 </span>
 </div>

--- a/docs/partials/api/angular-timeline.html
+++ b/docs/partials/api/angular-timeline.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/npm/npm.git/edit/master/dist/angular-timeline.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/npm/npm.git/blob/e76d86b/dist/angular-timeline.js#L29" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">angular-timeline</code>
+<a href="https://github.com/npm/npm/edit/master/dist/angular-timeline.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/npm/npm/blob/1608584/dist/angular-timeline.js#L29" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">angular-timeline</code>
 <div><span class="hint"></span>
 </div>
 </h1>

--- a/src/angular-timeline-animations.scss
+++ b/src/angular-timeline-animations.scss
@@ -1,5 +1,5 @@
 // only used in the example, not required for using angular-timeline
-.hidden {
+.timeline-hidden {
   display: block !important;
   opacity: 0;
 }


### PR DESCRIPTION
because it conflicts when used with bootstrap
Similarly when using angular-scroll animate, in functions we would add and remove class "timeline-hidden".
Works like a charm
