### PR TITLE
Update styles to support using attributes for timeline elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ show history or describe a sequence of events.
 
 [Demo](http://rpocklin.github.io/angular-timeline/example/index.html)
 
+[Demo using attributes](http://rpocklin.github.io/angular-timeline/example/index-attributes.html)
+
 [Demo without bootstrap](http://rpocklin.github.io/angular-timeline/example/index-no-bootstrap.html)
 
 [Original Implementation (HTML / Javascript)](http://bootsnipp.com/snippets/featured/timeline-responsive)

--- a/dist/angular-timeline-animations.css
+++ b/dist/angular-timeline-animations.css
@@ -3,16 +3,16 @@
   opacity: 0; }
 
 @media only screen and (min-width: 768px) {
-  .timeline timeline-event:nth-child(odd) timeline-panel.bounce-in {
+  .timeline .timeline-event:nth-child(odd) .timeline-panel.bounce-in {
     animation: cd-bounce-2 0.5s; }
-  .timeline timeline-event:nth-child(even) timeline-panel.bounce-in {
+  .timeline .timeline-event:nth-child(even) .timeline-panel.bounce-in {
     animation: cd-bounce-2-inverse 0.5s; } }
 
 @media only screen and (max-width: 767px) {
-  .timeline timeline-event timeline-panel.bounce-in {
+  .timeline .timeline-event .timeline-panel.bounce-in {
     animation: cd-bounce-2 0.5s; } }
 
-.timeline timeline-event timeline-badge.bounce-in {
+.timeline .timeline-event .timeline-badge.bounce-in {
   animation: cd-bounce-1 0.5s; }
 
 @-webkit-keyframes cd-bounce-2 {

--- a/dist/angular-timeline.css
+++ b/dist/angular-timeline.css
@@ -2,18 +2,18 @@
   margin-right: 4px;
   vertical-align: -1px; }
 
-img {
+.timeline img {
   vertical-align: middle; }
 
-.img-responsive {
+.timeline .img-responsive {
   display: block;
   height: auto;
   max-width: 100%; }
 
-.img-rounded {
+.timeline .img-rounded {
   border-radius: 3px; }
 
-.img-thumbnail {
+.timeline .img-thumbnail {
   background-color: #fff;
   border: 1px solid #ededf0;
   border-radius: 3px;
@@ -27,7 +27,7 @@ img {
   transition: all .2s ease-in-out;
   webkit-transition: all .2s ease-in-out; }
 
-.img-circle {
+.timeline .img-circle {
   border-radius: 50%; }
 
 .timeline {

--- a/dist/angular-timeline.css
+++ b/dist/angular-timeline.css
@@ -34,16 +34,15 @@ img {
   padding: 0;
   list-style: none;
   position: relative; }
-
-.timeline:before {
-  top: 0;
-  bottom: 0;
-  position: absolute;
-  content: " ";
-  width: 3px;
-  background-color: #cccccc;
-  left: 50%;
-  margin-left: -1.5px; }
+  .timeline:before {
+    top: 0;
+    bottom: 0;
+    position: absolute;
+    content: " ";
+    width: 3px;
+    background-color: #cccccc;
+    left: 50%;
+    margin-left: -1.5px; }
 
 .timeline-event {
   margin-bottom: 20px;
@@ -59,60 +58,7 @@ img {
     padding: 0.8em 1em;
     margin: 0; }
 
-timeline-badge.primary {
-  background-color: #2e6da4 !important; }
-
-timeline-badge.success {
-  background-color: #3f903f !important; }
-
-timeline-badge.warning {
-  background-color: #f0ad4e !important; }
-
-timeline-badge.danger {
-  background-color: #d9534f !important; }
-
-timeline-badge.info {
-  background-color: #5bc0de !important; }
-
-.timeline-title {
-  margin-top: 0; }
-
-timeline-panel > * {
-  margin: 0; }
-
-timeline-panel {
-  background-color: #fff;
-  float: left;
-  border: 1px solid #d4d4d4;
-  border-radius: 2px;
-  padding: 12px;
-  position: relative;
-  -webkit-box-shadow: 0 1px 6px rgba(0, 0, 0, 0.175);
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.175); }
-
-timeline-panel:before {
-  position: absolute;
-  top: 35px;
-  right: -15px;
-  display: inline-block;
-  border-top: 15px solid transparent;
-  border-left: 15px solid #ccc;
-  border-right: 0 solid #ccc;
-  border-bottom: 15px solid transparent;
-  content: " "; }
-
-timeline-panel:after {
-  position: absolute;
-  top: 36px;
-  right: -14px;
-  display: inline-block;
-  border-top: 14px solid transparent;
-  border-left: 14px solid #fff;
-  border-right: 0 solid #fff;
-  border-bottom: 14px solid transparent;
-  content: " "; }
-
-timeline-badge {
+.timeline-badge {
   box-shadow: 0 0 0 4px white, inset 0 2px 0 rgba(0, 0, 0, 0.08), 0 3px 0 4px rgba(0, 0, 0, 0.05);
   color: #fff;
   width: 50px;
@@ -130,32 +76,66 @@ timeline-badge {
   border-top-left-radius: 50%;
   border-bottom-right-radius: 50%;
   border-bottom-left-radius: 50%; }
+  .timeline-badge.primary {
+    background-color: #2e6da4 !important; }
+  .timeline-badge.success {
+    background-color: #3f903f !important; }
+  .timeline-badge.warning {
+    background-color: #f0ad4e !important; }
+  .timeline-badge.danger {
+    background-color: #d9534f !important; }
+  .timeline-badge.info {
+    background-color: #5bc0de !important; }
 
-.timeline-inverted timeline-panel {
+.timeline-title {
+  margin-top: 0; }
+
+.timeline-panel {
+  background-color: #fff;
+  float: left;
+  border: 1px solid #d4d4d4;
+  border-radius: 2px;
+  padding: 12px;
+  position: relative;
+  -webkit-box-shadow: 0 1px 6px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.175); }
+  .timeline-panel > * {
+    margin: 0; }
+  .timeline-panel:before {
+    position: absolute;
+    top: 35px;
+    right: -15px;
+    display: inline-block;
+    border-top: 15px solid transparent;
+    border-left: 15px solid #ccc;
+    border-right: 0 solid #ccc;
+    border-bottom: 15px solid transparent;
+    content: " "; }
+  .timeline-panel:after {
+    position: absolute;
+    top: 36px;
+    right: -14px;
+    display: inline-block;
+    border-top: 14px solid transparent;
+    border-left: 14px solid #fff;
+    border-right: 0 solid #fff;
+    border-bottom: 14px solid transparent;
+    content: " "; }
+
+.timeline-inverted .timeline-panel {
   float: right; }
+  .timeline-inverted .timeline-panel:before {
+    border-left-width: 0;
+    border-right-width: 15px;
+    left: -15px;
+    right: auto; }
+  .timeline-inverted .timeline-panel:after {
+    border-left-width: 0;
+    border-right-width: 14px;
+    left: -14px;
+    right: auto; }
 
-.timeline-inverted timeline-panel:before {
-  border-left-width: 0;
-  border-right-width: 15px;
-  left: -15px;
-  right: auto; }
-
-.timeline-inverted timeline-panel:after {
-  border-left-width: 0;
-  border-right-width: 14px;
-  left: -14px;
-  right: auto; }
-
-.timeline-event:before,
-.timeline-event:after {
-  content: " ";
-  display: table; }
-
-.timeline-event:after {
-  clear: both; }
-
-.timeline-event:before,
-.timeline-event:after {
+.timeline-event:before, .timeline-event:after {
   content: " ";
   display: table; }
 
@@ -163,7 +143,7 @@ timeline-badge {
   clear: both; }
 
 @media only screen and (min-width: 768px) {
-  timeline-panel {
+  .timeline-panel {
     width: calc(50% - 45px);
     width: -moz-calc(50% - 45px);
     width: -webkit-calc(50% - 45px); } }
@@ -171,25 +151,24 @@ timeline-badge {
 @media only screen and (max-width: 767px) {
   .timeline:before {
     left: 40px; }
-  timeline-panel {
+  .timeline-panel {
+    float: right;
     width: calc(100% - 85px);
     width: -moz-calc(100% - 85px);
     width: -webkit-calc(100% - 85px); }
-  timeline-badge {
+    .timeline-panel:before {
+      border-left-width: 0;
+      border-right-width: 15px;
+      left: -15px;
+      right: auto;
+      top: 46px; }
+    .timeline-panel:after {
+      border-left-width: 0;
+      border-right-width: 14px;
+      left: -14px;
+      right: auto;
+      top: 47px; }
+  .timeline-badge {
     left: 15px;
     margin-left: 0;
-    top: 36px; }
-  timeline-panel {
-    float: right; }
-  timeline-panel:before {
-    border-left-width: 0;
-    border-right-width: 15px;
-    left: -15px;
-    right: auto;
-    top: 46px; }
-  timeline-panel:after {
-    border-left-width: 0;
-    border-right-width: 14px;
-    left: -14px;
-    right: auto;
-    top: 47px; } }
+    top: 36px; } }

--- a/dist/angular-timeline.js
+++ b/dist/angular-timeline.js
@@ -13,6 +13,7 @@ angular.module('angular-timeline').directive('timelineBadge', function() {
     require: '^timelineEvent',
     restrict: 'AE',
     transclude: true,
+    replace: true,
     template: '<div class="timeline-badge" ng-transclude></div>'
   };
 });
@@ -30,6 +31,7 @@ angular.module('angular-timeline').directive('timeline', function() {
   return {
     restrict: 'AE',
     transclude: true,
+    replace: true,
     template: '<ul class="timeline" ng-transclude></ul>',
     controller: function() {}
   };
@@ -55,6 +57,7 @@ angular.module('angular-timeline').directive('timelineEvent', function() {
     require: '^timeline',
     restrict: 'AE',
     transclude: true,
+    replace: true,
     template: '<li class="timeline-event" ng-class-odd="oddClass" ng-class-even="evenClass" ng-transclude></li>',
     link: function(scope, element, attrs, controller) {
 
@@ -105,6 +108,7 @@ angular.module('angular-timeline').directive('timelineFooter', function() {
     require: '^timelinePanel',
     restrict: 'AE',
     transclude: true,
+    replace: true,
     template: '<div class="timeline-footer" ng-transclude></div>'
   };
 });
@@ -123,6 +127,7 @@ angular.module('angular-timeline').directive('timelineHeading', function() {
     require: '^timelinePanel',
     restrict: 'AE',
     transclude: true,
+    replace: true,
     template: '<div class="timeline-heading" ng-transclude></div>'
   };
 });
@@ -141,6 +146,7 @@ angular.module('angular-timeline').directive('timelinePanel', function() {
     require: '^timeline',
     restrict: 'AE',
     transclude: true,
+    replace: true,
     template: '<div class="timeline-panel" ng-transclude></div>'
   };
 });

--- a/example/app-attributes.js
+++ b/example/app-attributes.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var app = angular.module('example', [
+	'ngSanitize',
+  'ui.router',
+  'angular-timeline',
+	'angular-scroll-animate'
+]);
+
+app.config(function($stateProvider) {
+  $stateProvider.state('user', {
+    url:         '',
+    controller: 'ExampleCtrl',
+    templateUrl: 'example-attributes.html'
+  });
+});

--- a/example/example-attributes.html
+++ b/example/example-attributes.html
@@ -1,0 +1,37 @@
+<div class="container-fluid">
+  <h1>Angular Timeline</h1>
+  <button ng-click="addEvent()">Add New Event</button>
+  <button ng-click="leftAlign()">Left Side</button>
+  <button ng-click="rightAlign()">Right Side</button>
+  <button ng-click="defaultAlign()">Alternate Sides</button>
+  <br/>
+  <br/>
+  <div data-timeline>
+    <!-- can also hard-code to side="left" or side="right" -->
+    <div data-timeline-event ng-repeat="event in events" side="{{side}}">
+      <!-- uses angular-scroll-animate to give it some pop -->
+      <div data-timeline-badge class="{{event.badgeClass}} timeline-hidden"
+                      when-visible="animateElementIn" when-not-visible="animateElementOut">
+        <i class="glyphicon {{event.badgeIconClass}}"></i>
+      </div>
+
+      <!-- uses angular-scroll-animate to give it some pop -->
+      <div data-timeline-panel class="{{event.badgeClass}} timeline-hidden"
+                      when-visible="animateElementIn" when-not-visible="animateElementOut">
+        <div data-timeline-heading>
+          <h4>{{event.title}}</h4>
+
+          <p ng-if="event.when">
+            <small class="text-muted"><i class="glyphicon glyphicon-time"></i>{{event.when}}</small>
+          </p>
+          <p ng-if="event.titleContentHtml" ng-bind-html="event.titleContentHtml">
+          </p>
+        </div>
+        <p ng-bind-html="event.contentHtml"></p>
+        <div data-timeline-footer ng-if="event.footerContentHtml">
+          <span ng-bind-html="event.footerContentHtml"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/example/index-attributes.html
+++ b/example/index-attributes.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Angular Timeline Example</title>
+  <meta name="viewport" content="width=device-width">
+  <link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css" />
+  <link rel="stylesheet" href="../dist/angular-timeline.css" />
+  <link rel="stylesheet" href="../dist/angular-timeline-images.css" />
+  <link rel="stylesheet" href="../dist/angular-timeline-bootstrap.css" />
+  <link rel="stylesheet" href="../dist/angular-timeline-animations.css" />
+</head>
+
+<body ng-app="example">
+
+<style>
+  body { background-color: aliceblue; }
+  timeline-footer { background-color: aliceblue; }
+</style>
+
+<div ui-view></div>
+
+<script src="../bower_components/angular/angular.js"></script>
+<script src="../bower_components/angular-sanitize/angular-sanitize.js"></script>
+<script src="../bower_components/angular-ui-router/release/angular-ui-router.js"></script>
+<script src="../bower_components/angular-scroll-animate/dist/angular-scroll-animate.js"></script>
+<script src="../dist/angular-timeline.js"></script>
+
+<script src="app-attributes.js"></script>
+<script src="example-controller.js"></script>
+
+</body>
+</html>

--- a/src/angular-timeline-animations.scss
+++ b/src/angular-timeline-animations.scss
@@ -4,22 +4,22 @@
 }
 
 @media only screen and (min-width: 768px) {
-  .timeline timeline-event:nth-child(odd) timeline-panel.bounce-in {
+  .timeline .timeline-event:nth-child(odd) .timeline-panel.bounce-in {
     animation:  cd-bounce-2 0.5s;
   }
 
-  .timeline timeline-event:nth-child(even) timeline-panel.bounce-in {
+  .timeline .timeline-event:nth-child(even) .timeline-panel.bounce-in {
     animation:  cd-bounce-2-inverse 0.5s;
   }
 }
 
 @media only screen and (max-width: 767px) {
-  .timeline timeline-event timeline-panel.bounce-in {
+  .timeline .timeline-event .timeline-panel.bounce-in {
     animation:  cd-bounce-2 0.5s;
   }
 }
 
-.timeline timeline-event timeline-badge.bounce-in {
+.timeline .timeline-event .timeline-badge.bounce-in {
   animation:  cd-bounce-1 0.5s;
 }
 
@@ -198,5 +198,3 @@
     transform: scale(1);
   }
 }
-
-

--- a/src/angular-timeline-images.scss
+++ b/src/angular-timeline-images.scss
@@ -5,35 +5,37 @@
   }
 }
 
-img {
-  vertical-align: middle;
-}
+.timeline {
+  img {
+    vertical-align: middle;
+  }
 
-.img-responsive {
-  display: block;
-  height: auto;
-  max-width: 100%;
-}
+  .img-responsive {
+    display: block;
+    height: auto;
+    max-width: 100%;
+  }
 
-.img-rounded {
-  border-radius: 3px;
-}
+  .img-rounded {
+    border-radius: 3px;
+  }
 
-.img-thumbnail {
-  background-color: #fff;
-  border: 1px solid #ededf0;
-  border-radius: 3px;
-  display: inline-block;
-  height: auto;
-  line-height: 1.428571429;
-  max-width: 100%;
-  moz-transition: all .2s ease-in-out;
-  o-transition: all .2s ease-in-out;
-  padding: 2px;
-  transition: all .2s ease-in-out;
-  webkit-transition: all .2s ease-in-out;
-}
+  .img-thumbnail {
+    background-color: #fff;
+    border: 1px solid #ededf0;
+    border-radius: 3px;
+    display: inline-block;
+    height: auto;
+    line-height: 1.428571429;
+    max-width: 100%;
+    moz-transition: all .2s ease-in-out;
+    o-transition: all .2s ease-in-out;
+    padding: 2px;
+    transition: all .2s ease-in-out;
+    webkit-transition: all .2s ease-in-out;
+  }
 
-.img-circle {
-  border-radius: 50%;
+  .img-circle {
+    border-radius: 50%;
+  }
 }

--- a/src/angular-timeline.scss
+++ b/src/angular-timeline.scss
@@ -12,18 +12,18 @@ $timelineCenterColor: #cccccc;
   padding: 0;
   list-style: none;
   position: relative;
-}
 
 // center line
-.timeline:before {
-  top: 0;
-  bottom: 0;
-  position: absolute;
-  content: " ";
-  width: 3px;
-  background-color: $timelineCenterColor;
-  left: 50%;
-  margin-left: -1.5px;
+  &:before {
+    top: 0;
+    bottom: 0;
+    position: absolute;
+    content: " ";
+    width: 3px;
+    background-color: $timelineCenterColor;
+    left: 50%;
+    margin-left: -1.5px;
+  }
 }
 
 .timeline-event {
@@ -44,70 +44,7 @@ $timelineCenterColor: #cccccc;
   }
 }
 
-timeline-badge.primary {
-  background-color: #2e6da4 !important;
-}
-
-timeline-badge.success {
-  background-color: #3f903f !important;
-}
-
-timeline-badge.warning {
-  background-color: #f0ad4e !important;
-}
-
-timeline-badge.danger {
-  background-color: #d9534f !important;
-}
-
-timeline-badge.info {
-  background-color: #5bc0de !important;
-}
-
-.timeline-title {
-  margin-top: 0;
-}
-
-timeline-panel > * {
-  margin: 0;
-}
-
-timeline-panel {
-  background-color: $panelBackgroundColor;
-  float: left;
-  border: 1px solid #d4d4d4;
-  border-radius: 2px;
-  padding: 12px;
-  position: relative;
-  -webkit-box-shadow: 0 1px 6px rgba(0, 0, 0, 0.175);
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.175);
-}
-
-timeline-panel:before {
-  position: absolute;
-  top: $top;
-  right: -15px;
-  display: inline-block;
-  border-top: 15px solid transparent;
-  border-left: 15px solid $panelBorderColor;
-  border-right: 0 solid $panelBorderColor;
-  border-bottom: 15px solid transparent;
-  content: " ";
-}
-
-timeline-panel:after {
-  position: absolute;
-  top: $top + 1;
-  right: -14px;
-  display: inline-block;
-  border-top: 14px solid transparent;
-  border-left: 14px solid $panelBackgroundColor;
-  border-right: 0 solid $panelBackgroundColor;
-  border-bottom: 14px solid transparent;
-  content: " ";
-}
-
-timeline-badge {
+.timeline-badge {
   box-shadow: 0 0 0 4px white, inset 0 2px 0 rgba(0, 0, 0, 0.08), 0 3px 0 4px rgba(0, 0, 0, 0.05);
   color: #fff;
   width: 50px;
@@ -125,49 +62,104 @@ timeline-badge {
   border-top-left-radius: 50%;
   border-bottom-right-radius: 50%;
   border-bottom-left-radius: 50%;
+
+  &.primary {
+    background-color: #2e6da4 !important;
+  }
+
+  &.success {
+    background-color: #3f903f !important;
+  }
+
+  &.warning {
+    background-color: #f0ad4e !important;
+  }
+
+  &.danger {
+    background-color: #d9534f !important;
+  }
+
+ &.info {
+    background-color: #5bc0de !important;
+  }
 }
 
-.timeline-inverted timeline-panel {
-  float: right;
+.timeline-title {
+  margin-top: 0;
 }
 
-.timeline-inverted timeline-panel:before {
-  border-left-width: 0;
-  border-right-width: 15px;
-  left: -15px;
-  right: auto;
+.timeline-panel {
+  background-color: $panelBackgroundColor;
+  float: left;
+  border: 1px solid #d4d4d4;
+  border-radius: 2px;
+  padding: 12px;
+  position: relative;
+  -webkit-box-shadow: 0 1px 6px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.175);
+
+  > * {
+    margin: 0;
+  }
+
+  &:before {
+    position: absolute;
+    top: $top;
+    right: -15px;
+    display: inline-block;
+    border-top: 15px solid transparent;
+    border-left: 15px solid $panelBorderColor;
+    border-right: 0 solid $panelBorderColor;
+    border-bottom: 15px solid transparent;
+    content: " ";
+  }
+
+  &:after {
+    position: absolute;
+    top: $top + 1;
+    right: -14px;
+    display: inline-block;
+    border-top: 14px solid transparent;
+    border-left: 14px solid $panelBackgroundColor;
+    border-right: 0 solid $panelBackgroundColor;
+    border-bottom: 14px solid transparent;
+    content: " ";
+  }
 }
 
-.timeline-inverted timeline-panel:after {
-  border-left-width: 0;
-  border-right-width: 14px;
-  left: -14px;
-  right: auto;
+.timeline-inverted {
+  .timeline-panel {
+    float: right;
+
+    &:before {
+      border-left-width: 0;
+      border-right-width: 15px;
+      left: -15px;
+      right: auto;
+    }
+
+    &:after {
+      border-left-width: 0;
+      border-right-width: 14px;
+      left: -14px;
+      right: auto;
+    }
+  }
 }
 
-.timeline-event:before,
-.timeline-event:after {
-  content: " ";
-  display: table;
-}
+.timeline-event {
+  &:before, &:after {
+    content: " ";
+    display: table;
+  }
 
-.timeline-event:after {
-  clear: both;
-}
-
-.timeline-event:before,
-.timeline-event:after {
-  content: " ";
-  display: table;
-}
-
-.timeline-event:after {
-  clear: both;
+  &:after {
+    clear: both;
+  }
 }
 
 @media only screen and (min-width: 768px) {
-  
-  timeline-panel {
+  .timeline-panel {
     width: calc(50% - 45px);
     width: -moz-calc(50% - 45px);
     width: -webkit-calc(50% - 45px);
@@ -175,41 +167,38 @@ timeline-badge {
 }
 
 @media only screen and (max-width: 767px) {
-
   .timeline:before {
     left: 40px;
   }
 
-  timeline-panel {
+  .timeline-panel {
+    float: right;
     width: calc(100% - 85px);
     width: -moz-calc(100% - 85px);
     width: -webkit-calc(100% - 85px);
+  
+    &:before {
+      border-left-width: 0;
+      border-right-width: 15px;
+      left: -15px;
+      right: auto;
+      top: $top + 11px;
+    }
+
+    &:after {
+      border-left-width: 0;
+      border-right-width: 14px;
+      left: -14px;
+      right: auto;
+      top: $top + 12px;
+    }
   }
 
-  timeline-badge {
+  .timeline-badge {
     left: 15px;
     margin-left: 0;
     top: $top + 1;
   }
 
-  timeline-panel {
-    float: right;
-  }
-
-  timeline-panel:before {
-    border-left-width: 0;
-    border-right-width: 15px;
-    left: -15px;
-    right: auto;
-    top: $top + 11px;
-  }
-
-  timeline-panel:after {
-    border-left-width: 0;
-    border-right-width: 14px;
-    left: -14px;
-    right: auto;
-    top: $top + 12px;
-  }
 }
 

--- a/src/timeline-badge-directive.js
+++ b/src/timeline-badge-directive.js
@@ -13,6 +13,7 @@ angular.module('angular-timeline').directive('timelineBadge', function() {
     require: '^timelineEvent',
     restrict: 'AE',
     transclude: true,
+    replace: true,
     template: '<div class="timeline-badge" ng-transclude></div>'
   };
 });

--- a/src/timeline-directive.js
+++ b/src/timeline-directive.js
@@ -12,6 +12,7 @@ angular.module('angular-timeline').directive('timeline', function() {
   return {
     restrict: 'AE',
     transclude: true,
+    replace: true,
     template: '<ul class="timeline" ng-transclude></ul>',
     controller: function() {}
   };

--- a/src/timeline-event-directive.js
+++ b/src/timeline-event-directive.js
@@ -19,6 +19,7 @@ angular.module('angular-timeline').directive('timelineEvent', function() {
     require: '^timeline',
     restrict: 'AE',
     transclude: true,
+    replace: true,
     template: '<li class="timeline-event" ng-class-odd="oddClass" ng-class-even="evenClass" ng-transclude></li>',
     link: function(scope, element, attrs, controller) {
 

--- a/src/timeline-footer-directive.js
+++ b/src/timeline-footer-directive.js
@@ -13,6 +13,7 @@ angular.module('angular-timeline').directive('timelineFooter', function() {
     require: '^timelinePanel',
     restrict: 'AE',
     transclude: true,
+    replace: true,
     template: '<div class="timeline-footer" ng-transclude></div>'
   };
 });

--- a/src/timeline-heading-directive.js
+++ b/src/timeline-heading-directive.js
@@ -13,6 +13,7 @@ angular.module('angular-timeline').directive('timelineHeading', function() {
     require: '^timelinePanel',
     restrict: 'AE',
     transclude: true,
+    replace: true,
     template: '<div class="timeline-heading" ng-transclude></div>'
   };
 });

--- a/src/timeline-panel-directive.js
+++ b/src/timeline-panel-directive.js
@@ -13,6 +13,7 @@ angular.module('angular-timeline').directive('timelinePanel', function() {
     require: '^timeline',
     restrict: 'AE',
     transclude: true,
+    replace: true,
     template: '<div class="timeline-panel" ng-transclude></div>'
   };
 });


### PR DESCRIPTION
# Problem

Currently, the style sheet in place has a few places where it is looking for the timeline-\* tags instead of relying on CSS classes. This causes users that want to keep their HTML valid issues as they need to duplicate the styles for angular-timeline.
## Changes
- Updated SCSS file to support using attributes
  - Cleaned up the SCSS to take advantage of nested classes
  - Swapped the `img` style to be nested inside the timeline class so it would not collide with other styles set up by the user
- Added an example that renders the timeline using only HTML data attributes
### Notes
- Resubmitting this based on the 1.7.0 release
- I did not include updated ngdocs due to it not correctly interpolating the links
- Package version was not bumped for this. While I believe this would fall under a revision classification, I felt it best to leave it up to you on how you wanted to update the version

Please let me know if you'd like any changes to what I've done here.
