### PR TITLE
Export module name as default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/angular-timeline');
+module.exports = 'angular-timeline';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "http://github.com/rpocklin/angular-timeline.git"
   },
-  "main": "./dist/angular-timeline.js",
+  "main": "index.js",
   "keywords": [
     "angular",
     "timeline",


### PR DESCRIPTION
# Problem
I want to add this dependency to my code by importing it in my main `angularjs` module file, like so:
``` javascript
import angularTimeline from 'angular-timeline';

angular.module('app', [angularTimeline])
```

But your library is not exporting the name as the default.
This PR fixes that enough to work!